### PR TITLE
Fixed container.rb definition

### DIFF
--- a/objects/container.rb
+++ b/objects/container.rb
@@ -7,7 +7,7 @@ class Container < GameObject
   include HasInventory
 
   #Create new container. Capacity is unlimited if unset.
-  def initialize(capacity = nil, *args)
+  def initialize(*args, capacity: nil)
     super(*args)
 
     @generic = "container"


### PR DESCRIPTION
Fixed an issue with the container definition causing creating a new container to create it with the goid of the room it's in, breaking the game.